### PR TITLE
fix: remove debug console.log statements from virtual scroll plugin

### DIFF
--- a/docs/src/routes/docs/plugins/add-virtual-scroll/+page.svx
+++ b/docs/src/routes/docs/plugins/add-virtual-scroll/+page.svx
@@ -157,9 +157,6 @@ Default `200`. Number of pixels from the bottom to trigger `onLoadMore`.
 ### `getRowHeight?: (item: Item) => number`
 Optional function to get the exact height of a specific row. Enables precise variable row heights.
 
-### `debug?: boolean`
-Default `false`. Enable debug mode to show virtualization info in the console.
-
 ## Plugin State
 
 <Callout type="info">State provided by <code>addVirtualScroll</code>.</Callout>

--- a/src/lib/plugins/addVirtualScroll.ts
+++ b/src/lib/plugins/addVirtualScroll.ts
@@ -19,8 +19,7 @@ export type { ScrollToIndexOptions, VirtualScrollConfig, VirtualScrollState, Vis
 const DEFAULTS = {
     estimatedRowHeight: 40,
     bufferSize: 10,
-    loadMoreThreshold: 200,
-    debug: false
+    loadMoreThreshold: 200
 } as const
 
 /**
@@ -61,8 +60,7 @@ export const addVirtualScroll =
         loadMoreThreshold = DEFAULTS.loadMoreThreshold,
         estimatedRowHeight = DEFAULTS.estimatedRowHeight,
         bufferSize = DEFAULTS.bufferSize,
-        getRowHeight,
-        debug = DEFAULTS.debug
+        getRowHeight
     }: VirtualScrollConfig<Item> = {}): TablePlugin<
         Item,
         VirtualScrollState<Item>,
@@ -121,14 +119,7 @@ export const addVirtualScroll =
         const topSpacerHeight: Readable<number> = derived(
             [rowIds, visibleRange],
             ([$rowIds, $range]) => {
-                const height = heightManager.getOffsetForIndex($rowIds, $range.start)
-                if (debug) {
-                    console.log('[VirtualScroll] topSpacerHeight', {
-                        rangeStart: $range.start,
-                        height
-                    })
-                }
-                return height
+                return heightManager.getOffsetForIndex($rowIds, $range.start)
             }
         )
 
@@ -136,16 +127,7 @@ export const addVirtualScroll =
             [rowIds, visibleRange, totalHeight],
             ([$rowIds, $range, $total]) => {
                 const endOffset = heightManager.getOffsetForIndex($rowIds, $range.end)
-                const height = Math.max(0, $total - endOffset)
-                if (debug) {
-                    console.log('[VirtualScroll] bottomSpacerHeight', {
-                        rangeEnd: $range.end,
-                        endOffset,
-                        totalHeight: $total,
-                        height
-                    })
-                }
-                return height
+                return Math.max(0, $total - endOffset)
             }
         )
 
@@ -174,13 +156,6 @@ export const addVirtualScroll =
                 loadMorePending = true
                 isLoading.set(true)
 
-                if (debug) {
-                    console.log('[VirtualScroll] Triggering onLoadMore', {
-                        distanceFromBottom,
-                        threshold: loadMoreThreshold
-                    })
-                }
-
                 const result = onLoadMore()
                 if (result instanceof Promise) {
                     result.finally(() => {
@@ -201,14 +176,6 @@ export const addVirtualScroll =
             const target = event.target as HTMLElement
             const newScrollTop = target.scrollTop
 
-            if (debug) {
-                console.log('[VirtualScroll] handleScroll', {
-                    scrollTop: newScrollTop,
-                    scrollHeight: target.scrollHeight,
-                    clientHeight: target.clientHeight
-                })
-            }
-
             scrollTop.set(newScrollTop)
 
             checkLoadMore()
@@ -222,20 +189,11 @@ export const addVirtualScroll =
 
             // Set initial viewport height
             const initialHeight = node.clientHeight
-            if (debug) {
-                console.log('[VirtualScroll] Action attached, initial clientHeight:', initialHeight)
-            }
             viewportHeight.set(initialHeight)
 
             // Create ResizeObserver to track viewport size changes
             const resizeObserver = new ResizeObserver((entries) => {
                 for (const entry of entries) {
-                    if (debug) {
-                        console.log(
-                            '[VirtualScroll] ResizeObserver fired, new height:',
-                            entry.contentRect.height
-                        )
-                    }
                     viewportHeight.set(entry.contentRect.height)
                 }
             })
@@ -261,11 +219,6 @@ export const addVirtualScroll =
          */
         const scrollToIndex = (index: number, options: ScrollToIndexOptions = {}) => {
             if (!scrollContainer) {
-                if (debug) {
-                    console.warn(
-                        '[VirtualScroll] scrollToIndex called but no scroll container attached'
-                    )
-                }
                 return
             }
 
@@ -273,12 +226,6 @@ export const addVirtualScroll =
             const $rowIds = get(rowIds)
 
             if (index < 0 || index >= $rowIds.length) {
-                if (debug) {
-                    console.warn('[VirtualScroll] scrollToIndex: index out of bounds', {
-                        index,
-                        totalRows: $rowIds.length
-                    })
-                }
                 return
             }
 
@@ -322,15 +269,6 @@ export const addVirtualScroll =
                 top: Math.max(0, scrollPosition),
                 behavior
             })
-
-            if (debug) {
-                console.log('[VirtualScroll] scrollToIndex', {
-                    index,
-                    targetOffset,
-                    scrollPosition,
-                    align
-                })
-            }
         }
 
         /**
@@ -353,15 +291,6 @@ export const addVirtualScroll =
                 // Force recalculation of derived stores by updating rowIds
                 // (touching it with the same value)
                 rowIds.update((v) => v)
-
-                if (debug) {
-                    console.log('[VirtualScroll] Row measured', {
-                        rowId,
-                        height,
-                        averageHeight: heightManager.getAverageHeight(),
-                        measuredCount: heightManager.size
-                    })
-                }
             }
         }
 
@@ -447,19 +376,6 @@ export const addVirtualScroll =
 
                     // Return only the visible subset
                     const visibleRows = $rows.slice(range.start, range.end)
-
-                    if (debug) {
-                        console.log('[VirtualScroll] derivePageRows', {
-                            totalRows: $rows.length,
-                            scrollTop: $scrollTop,
-                            viewportHeight: $viewportHeight,
-                            bufferSize,
-                            range,
-                            visibleRowsCount: visibleRows.length,
-                            estimatedRowHeight,
-                            avgHeight: heightManager.getAverageHeight()
-                        })
-                    }
 
                     set(visibleRows)
                 }

--- a/src/lib/plugins/addVirtualScroll.types.ts
+++ b/src/lib/plugins/addVirtualScroll.types.ts
@@ -44,12 +44,6 @@ export interface VirtualScrollConfig<Item> {
      * If provided, enables variable row heights.
      */
     getRowHeight?: (_item: Item) => number
-
-    /**
-     * Enable debug mode to show virtualization info in console.
-     * @default false
-     */
-    debug?: boolean
 }
 
 /**

--- a/src/lib/utils/HeightManager.ts
+++ b/src/lib/utils/HeightManager.ts
@@ -172,19 +172,6 @@ export class HeightManager {
             end = rowIds.length
         }
 
-        // DEBUG
-        console.log('[HeightManager] getVisibleRange', {
-            rowCount: rowIds.length,
-            scrollTop,
-            viewportHeight,
-            bufferSize,
-            avgHeight,
-            bottomEdge,
-            start,
-            end,
-            measuredCount: this.measuredCount
-        })
-
         return { start, end }
     }
 

--- a/src/routes/virtual-scroll/+page.svelte
+++ b/src/routes/virtual-scroll/+page.svelte
@@ -97,8 +97,7 @@
             bufferSize: 10,
             onLoadMore: loadMoreItems,
             hasMore,
-            loadMoreThreshold: 200,
-            debug: true
+            loadMoreThreshold: 200
         })
     })
 


### PR DESCRIPTION
## Summary

Removes debug console.log statements from the virtual scroll plugin that were causing CI failures due to the "Check for debugging statements" workflow.

## Changes

🐛 **Bug Fixes**
- Remove all `console.log` and `console.warn` statements from `addVirtualScroll.ts`
- Remove debug `console.log` from `HeightManager.ts`
- Remove `debug` config option from `VirtualScrollConfig` type
- Update documentation to remove debug option reference

## Commits

- [`2d4de45`](https://github.com/humanspeak/svelte-headless-table/commit/2d4de45) fix: remove debug console.log statements from virtual scroll plugin

---

🤖 Generated with [Claude Code](https://claude.ai/code)