### PR TITLE
fix(virtual-scroll): prevent scroll cascade on scrollbar drag

### DIFF
--- a/docs/src/routes/docs/examples/virtual-scroll/VirtualScrollExample.svelte
+++ b/docs/src/routes/docs/examples/virtual-scroll/VirtualScrollExample.svelte
@@ -373,6 +373,7 @@
     table {
         width: 100%;
         border-collapse: collapse;
+        table-layout: fixed;
         margin: 0;
     }
 
@@ -402,6 +403,9 @@
         padding: 0.5rem 0.75rem;
         text-align: left;
         border-bottom: 1px solid rgba(128, 128, 128, 0.2);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     th {

--- a/docs/src/routes/docs/plugins/add-virtual-scroll/+page.svx
+++ b/docs/src/routes/docs/plugins/add-virtual-scroll/+page.svx
@@ -106,6 +106,9 @@ sidebar_title: addVirtualScroll
     height: 500px;
     overflow-y: auto;
   }
+  table {
+    table-layout: fixed;
+  }
 </style>
 ```
 
@@ -235,6 +238,7 @@ Manually notify the plugin that a row has been measured. Usually not needed when
 
 ## Performance Tips
 
+- **Use `table-layout: fixed`** on your `<table>` element. With virtual scroll, only a subset of rows is rendered at any time. The default `table-layout: auto` recalculates column widths based on visible content, causing header columns to shift as you scroll through rows with varying content lengths. `table-layout: fixed` locks column widths to the header, preventing layout jitter.
 - Use a reasonable `bufferSize` (10-20) to balance between smooth scrolling and DOM size
 - The `estimatedRowHeight` doesn't need to be exact - actual heights are measured automatically
 - For very large datasets (100,000+ rows), consider server-side pagination combined with virtual scroll

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -5,6 +5,8 @@ procs:
         autorestart: false
     pkg:
         shell: pnpm -w -r --filter @humanspeak/svelte-headless-table run dev:pkg
+    dev:
+        shell: pnpm -w run dev
     docs:
         shell: pnpm --filter docs run dev
     sitemap:

--- a/src/lib/plugins/addVirtualScroll.ts
+++ b/src/lib/plugins/addVirtualScroll.ts
@@ -103,7 +103,7 @@ export const addVirtualScroll =
         let currentRange: VisibleRange = { start: 0, end: 0 }
         const visibleRange: Readable<VisibleRange> = derived(
             [rowIds, scrollTop, viewportHeight],
-            ([$rowIds, $scrollTop, $viewportHeight]) => {
+            ([$rowIds, $scrollTop, $viewportHeight], set) => {
                 const range = heightManager.getVisibleRange(
                     $rowIds,
                     $scrollTop,
@@ -111,11 +111,12 @@ export const addVirtualScroll =
                     bufferSize
                 )
                 if (range.start === currentRange.start && range.end === currentRange.end) {
-                    return currentRange
+                    return
                 }
                 currentRange = range
-                return range
-            }
+                set(range)
+            },
+            currentRange
         )
 
         // Total height of all rows

--- a/src/lib/plugins/addVirtualScroll.ts
+++ b/src/lib/plugins/addVirtualScroll.ts
@@ -97,16 +97,24 @@ export const addVirtualScroll =
         // Cache for row lookup (set by derivePageRows)
         let allRowsCache: BodyRow<Item>[] = []
 
-        // Visible range calculation
+        // Visible range calculation.
+        // Return the same object reference when the range hasn't changed to avoid
+        // unnecessary downstream store updates (spacer heights, rendered rows).
+        let currentRange: VisibleRange = { start: 0, end: 0 }
         const visibleRange: Readable<VisibleRange> = derived(
             [rowIds, scrollTop, viewportHeight],
             ([$rowIds, $scrollTop, $viewportHeight]) => {
-                return heightManager.getVisibleRange(
+                const range = heightManager.getVisibleRange(
                     $rowIds,
                     $scrollTop,
                     $viewportHeight,
                     bufferSize
                 )
+                if (range.start === currentRange.start && range.end === currentRange.end) {
+                    return currentRange
+                }
+                currentRange = range
+                return range
             }
         )
 
@@ -174,9 +182,7 @@ export const addVirtualScroll =
          */
         const handleScroll = (event: Event) => {
             const target = event.target as HTMLElement
-            const newScrollTop = target.scrollTop
-
-            scrollTop.set(newScrollTop)
+            scrollTop.set(target.scrollTop)
 
             checkLoadMore()
         }
@@ -186,6 +192,12 @@ export const addVirtualScroll =
          */
         const virtualScroll: Action<HTMLElement> = (node) => {
             scrollContainer = node
+
+            // Disable overflow-anchor to prevent the browser from adjusting
+            // scrollTop when spacer heights change. Without this, a feedback
+            // loop occurs: spacer change → browser adjusts scrollTop → scroll
+            // event → new visible range → spacer change → cascades to bottom.
+            node.style.overflowAnchor = 'none'
 
             // Set initial viewport height
             const initialHeight = node.clientHeight

--- a/src/routes/virtual-scroll/+page.svelte
+++ b/src/routes/virtual-scroll/+page.svelte
@@ -279,6 +279,15 @@
         </p>
         <div class="table-container" use:virtualScroll>
             <table {...$tableAttrs}>
+                <colgroup>
+                    <col style="width: 8%" />
+                    <col style="width: 14%" />
+                    <col style="width: 22%" />
+                    <col style="width: 12%" />
+                    <col style="width: 14%" />
+                    <col style="width: 10%" />
+                    <col style="width: 12%" />
+                </colgroup>
                 <thead>
                     {#each $headerRows as headerRow (headerRow.id)}
                         <Subscribe attrs={headerRow.attrs()} let:attrs>
@@ -520,6 +529,7 @@ const {
     table {
         width: 100%;
         border-collapse: collapse;
+        table-layout: fixed;
     }
 
     thead {
@@ -534,6 +544,9 @@ const {
         padding: 0.75rem;
         text-align: left;
         border-bottom: 1px solid #ddd;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     th {


### PR DESCRIPTION
## Summary

Fixes a scroll cascade bug in `addVirtualScroll` where dragging the scrollbar causes the viewport to run away to the bottom of the table. The root cause is a feedback loop: spacer height changes trigger browser scroll adjustments (`overflow-anchor`), which fire scroll events, which recalculate the visible range, which changes spacers again — cascading until reaching the bottom.

## Changes

🐛 **Fix scroll cascade feedback loop** — Set `overflow-anchor: none` on the scroll container to prevent the browser from adjusting `scrollTop` when spacer heights change. Also return stable object references from the `visibleRange` derived store to avoid unnecessary downstream recalculations.

📚 **Document `table-layout: fixed` best practice** — Add performance tip to docs explaining why `table-layout: fixed` prevents column width jitter during virtual scrolling.

🔧 **Improve table layout in examples** — Add `table-layout: fixed`, text truncation styles, and `colgroup` to virtual scroll examples for stable column widths.

🔧 **Add dev server to mprocs** — Include the root dev server in `mprocs.yaml` for convenience.

## Commits

- [`b50b1f0`](https://github.com/humanspeak/svelte-headless-table/commit/b50b1f00443aafa915f39e87a96af3e4367a3ada) fix(virtual-scroll): prevent scroll cascade from spacer feedback loop
- [`e71a196`](https://github.com/humanspeak/svelte-headless-table/commit/e71a1965149598d1338441021453c7b329806610) feat(docs): add table-layout fixed and column truncation for virtual scroll
