### PR TITLE
perf: eliminate O(n²) bottlenecks in table rendering pipeline

### DIFF
--- a/src/lib/bodyRows.ts
+++ b/src/lib/bodyRows.ts
@@ -373,9 +373,7 @@ export const getColumnedBodyRows = <Item, Plugins extends AnyPlugins = AnyPlugin
         columnedRows[rowIdx].cells = visibleCells
         // Include hidden cells in `cellForId` to allow row transformations on
         // hidden cells.
-        cells.forEach((cell) => {
-            columnedRows[rowIdx].cellForId[cell.id] = cell
-        })
+        columnedRows[rowIdx].cellForId = Object.fromEntries(cellById)
     })
     return columnedRows
 }

--- a/src/lib/bodyRows.ts
+++ b/src/lib/bodyRows.ts
@@ -368,11 +368,8 @@ export const getColumnedBodyRows = <Item, Plugins extends AnyPlugins = AnyPlugin
             clonedCell.row = columnedRows[rowIdx]
             return clonedCell
         })
-        const visibleCells = columnIdOrder
-            .map((cid) => {
-                return cells.find((c) => c.id === cid)
-            })
-            .filter(nonUndefined)
+        const cellById = new Map(cells.map((c) => [c.id, c]))
+        const visibleCells = columnIdOrder.map((cid) => cellById.get(cid)).filter(nonUndefined)
         columnedRows[rowIdx].cells = visibleCells
         // Include hidden cells in `cellForId` to allow row transformations on
         // hidden cells.

--- a/src/lib/createViewModel.ts
+++ b/src/lib/createViewModel.ts
@@ -368,13 +368,13 @@ export const createViewModel = <Item, Plugins extends AnyPlugins = AnyPlugins>(
             row.injectState(tableState)
             row.cells.forEach((cell) => cell.injectState(tableState))
             for (const [pluginName, pluginInstance] of pluginEntries) {
-                if (pluginInstance.hooks?.['tbody.tr'] !== undefined) {
-                    row.applyHook(pluginName, pluginInstance.hooks['tbody.tr'](row))
+                const trHook = pluginInstance.hooks?.['tbody.tr']
+                if (trHook !== undefined) {
+                    row.applyHook(pluginName, trHook(row))
                 }
-                if (pluginInstance.hooks?.['tbody.tr.td'] !== undefined) {
-                    row.cells.forEach((cell) =>
-                        cell.applyHook(pluginName, pluginInstance.hooks!['tbody.tr.td']!(cell))
-                    )
+                const tdHook = pluginInstance.hooks?.['tbody.tr.td']
+                if (tdHook !== undefined) {
+                    row.cells.forEach((cell) => cell.applyHook(pluginName, tdHook(cell)))
                 }
             }
         })
@@ -399,13 +399,13 @@ export const createViewModel = <Item, Plugins extends AnyPlugins = AnyPlugins>(
             row.injectState(tableState)
             row.cells.forEach((cell) => cell.injectState(tableState))
             for (const [pluginName, pluginInstance] of pluginEntries) {
-                if (pluginInstance.hooks?.['tbody.tr'] !== undefined) {
-                    row.applyHook(pluginName, pluginInstance.hooks['tbody.tr'](row))
+                const trHook = pluginInstance.hooks?.['tbody.tr']
+                if (trHook !== undefined) {
+                    row.applyHook(pluginName, trHook(row))
                 }
-                if (pluginInstance.hooks?.['tbody.tr.td'] !== undefined) {
-                    row.cells.forEach((cell) =>
-                        cell.applyHook(pluginName, pluginInstance.hooks!['tbody.tr.td']!(cell))
-                    )
+                const tdHook = pluginInstance.hooks?.['tbody.tr.td']
+                if (tdHook !== undefined) {
+                    row.cells.forEach((cell) => cell.applyHook(pluginName, tdHook(cell)))
                 }
             }
         })
@@ -423,13 +423,13 @@ export const createViewModel = <Item, Plugins extends AnyPlugins = AnyPlugins>(
             row.injectState(tableState)
             row.cells.forEach((cell) => cell.injectState(tableState))
             for (const [pluginName, pluginInstance] of pluginEntries) {
-                if (pluginInstance.hooks?.['thead.tr'] !== undefined) {
-                    row.applyHook(pluginName, pluginInstance.hooks['thead.tr'](row))
+                const trHook = pluginInstance.hooks?.['thead.tr']
+                if (trHook !== undefined) {
+                    row.applyHook(pluginName, trHook(row))
                 }
-                if (pluginInstance.hooks?.['thead.tr.th'] !== undefined) {
-                    row.cells.forEach((cell) =>
-                        cell.applyHook(pluginName, pluginInstance.hooks!['thead.tr.th']!(cell))
-                    )
+                const thHook = pluginInstance.hooks?.['thead.tr.th']
+                if (thHook !== undefined) {
+                    row.cells.forEach((cell) => cell.applyHook(pluginName, thHook(cell)))
                 }
             }
         })

--- a/src/lib/createViewModel.ts
+++ b/src/lib/createViewModel.ts
@@ -393,22 +393,10 @@ export const createViewModel = <Item, Plugins extends AnyPlugins = AnyPlugins>(
         pageRows = fn(pageRows as any) as any
     })
 
+    // Page rows are a subset of the same object references already processed
+    // by injectedRows — no need to re-inject state or re-apply hooks.
     const injectedPageRows = derived(pageRows, ($pageRows) => {
         derivationCalls.injectedPageRows++
-        $pageRows.forEach((row) => {
-            row.injectState(tableState)
-            row.cells.forEach((cell) => cell.injectState(tableState))
-            for (const [pluginName, pluginInstance] of pluginEntries) {
-                const trHook = pluginInstance.hooks?.['tbody.tr']
-                if (trHook !== undefined) {
-                    row.applyHook(pluginName, trHook(row))
-                }
-                const tdHook = pluginInstance.hooks?.['tbody.tr.td']
-                if (tdHook !== undefined) {
-                    row.cells.forEach((cell) => cell.applyHook(pluginName, tdHook(cell)))
-                }
-            }
-        })
         _pageRows.set($pageRows)
         return $pageRows
     })

--- a/src/lib/createViewModel.ts
+++ b/src/lib/createViewModel.ts
@@ -360,27 +360,23 @@ export const createViewModel = <Item, Plugins extends AnyPlugins = AnyPlugins>(
         rows = fn(rows as any) as any
     })
 
+    const pluginEntries = Object.entries(pluginInstances)
+
     const injectedRows = derived(rows, ($rows) => {
         derivationCalls.injectedRows++
-        // Inject state.
         $rows.forEach((row) => {
             row.injectState(tableState)
-            row.cells.forEach((cell) => {
-                cell.injectState(tableState)
-            })
-        })
-        // Apply plugin component hooks.
-        Object.entries(pluginInstances).forEach(([pluginName, pluginInstance]) => {
-            $rows.forEach((row) => {
+            row.cells.forEach((cell) => cell.injectState(tableState))
+            for (const [pluginName, pluginInstance] of pluginEntries) {
                 if (pluginInstance.hooks?.['tbody.tr'] !== undefined) {
                     row.applyHook(pluginName, pluginInstance.hooks['tbody.tr'](row))
                 }
-                row.cells.forEach((cell) => {
-                    if (pluginInstance.hooks?.['tbody.tr.td'] !== undefined) {
-                        cell.applyHook(pluginName, pluginInstance.hooks['tbody.tr.td'](cell))
-                    }
-                })
-            })
+                if (pluginInstance.hooks?.['tbody.tr.td'] !== undefined) {
+                    row.cells.forEach((cell) =>
+                        cell.applyHook(pluginName, pluginInstance.hooks!['tbody.tr.td']!(cell))
+                    )
+                }
+            }
         })
         _rows.set($rows)
         return $rows
@@ -399,25 +395,19 @@ export const createViewModel = <Item, Plugins extends AnyPlugins = AnyPlugins>(
 
     const injectedPageRows = derived(pageRows, ($pageRows) => {
         derivationCalls.injectedPageRows++
-        // Inject state.
         $pageRows.forEach((row) => {
             row.injectState(tableState)
-            row.cells.forEach((cell) => {
-                cell.injectState(tableState)
-            })
-        })
-        // Apply plugin component hooks.
-        Object.entries(pluginInstances).forEach(([pluginName, pluginInstance]) => {
-            $pageRows.forEach((row) => {
+            row.cells.forEach((cell) => cell.injectState(tableState))
+            for (const [pluginName, pluginInstance] of pluginEntries) {
                 if (pluginInstance.hooks?.['tbody.tr'] !== undefined) {
                     row.applyHook(pluginName, pluginInstance.hooks['tbody.tr'](row))
                 }
-                row.cells.forEach((cell) => {
-                    if (pluginInstance.hooks?.['tbody.tr.td'] !== undefined) {
-                        cell.applyHook(pluginName, pluginInstance.hooks['tbody.tr.td'](cell))
-                    }
-                })
-            })
+                if (pluginInstance.hooks?.['tbody.tr.td'] !== undefined) {
+                    row.cells.forEach((cell) =>
+                        cell.applyHook(pluginName, pluginInstance.hooks!['tbody.tr.td']!(cell))
+                    )
+                }
+            }
         })
         _pageRows.set($pageRows)
         return $pageRows
@@ -429,25 +419,19 @@ export const createViewModel = <Item, Plugins extends AnyPlugins = AnyPlugins>(
             columns,
             $injectedColumns.map((c) => c.id)
         )
-        // Inject state.
         $headerRows.forEach((row) => {
             row.injectState(tableState)
-            row.cells.forEach((cell) => {
-                cell.injectState(tableState)
-            })
-        })
-        // Apply plugin component hooks.
-        Object.entries(pluginInstances).forEach(([pluginName, pluginInstance]) => {
-            $headerRows.forEach((row) => {
+            row.cells.forEach((cell) => cell.injectState(tableState))
+            for (const [pluginName, pluginInstance] of pluginEntries) {
                 if (pluginInstance.hooks?.['thead.tr'] !== undefined) {
                     row.applyHook(pluginName, pluginInstance.hooks['thead.tr'](row))
                 }
-                row.cells.forEach((cell) => {
-                    if (pluginInstance.hooks?.['thead.tr.th'] !== undefined) {
-                        cell.applyHook(pluginName, pluginInstance.hooks['thead.tr.th'](cell))
-                    }
-                })
-            })
+                if (pluginInstance.hooks?.['thead.tr.th'] !== undefined) {
+                    row.cells.forEach((cell) =>
+                        cell.applyHook(pluginName, pluginInstance.hooks!['thead.tr.th']!(cell))
+                    )
+                }
+            }
         })
         _headerRows.set($headerRows)
         return $headerRows

--- a/src/lib/plugins/addColumnOrder.test.ts
+++ b/src/lib/plugins/addColumnOrder.test.ts
@@ -76,7 +76,7 @@ test('empty columnIdOrder: all columns shown in original order', () => {
     expect(visibleColumns.map((c) => c.id)).toStrictEqual(['firstName', 'lastName', 'age'])
 })
 
-test('non-existent column ID in order: does not break reordering', () => {
+test('non-existent column ID in order: skips missing IDs gracefully', () => {
     const table = createTable(data, {
         order: addColumnOrder({ initialColumnIdOrder: ['age', 'nonExistent', 'firstName'] })
     })
@@ -88,7 +88,6 @@ test('non-existent column ID in order: does not break reordering', () => {
     const vm = table.createViewModel(columns)
     const visibleColumns = get(vm.visibleColumns)
 
-    // Non-existent ID causes splice(-1,1) which pops last remaining element.
-    // The actual order is: age (matched), lastName (popped by nonExistent), firstName (matched)
-    expect(visibleColumns.map((c) => c.id)).toStrictEqual(['age', 'lastName', 'firstName'])
+    // Non-existent IDs are skipped; matched columns appear in order, then unspecified columns
+    expect(visibleColumns.map((c) => c.id)).toStrictEqual(['age', 'firstName', 'lastName'])
 })

--- a/src/lib/plugins/addColumnOrder.ts
+++ b/src/lib/plugins/addColumnOrder.ts
@@ -57,15 +57,20 @@ export const addColumnOrder =
 
         const deriveFlatColumns: DeriveFlatColumnsFn<Item> = (flatColumns) => {
             return derived([flatColumns, columnIdOrder], ([$flatColumns, $columnIdOrder]) => {
-                const _flatColumns = [...$flatColumns]
+                const colById = new Map($flatColumns.map((c) => [c.id, c]))
                 const orderedFlatColumns: typeof $flatColumns = []
+                const seen = new Set<string>()
                 $columnIdOrder.forEach((id) => {
-                    const colIdx = _flatColumns.findIndex((c) => c.id === id)
-                    orderedFlatColumns.push(..._flatColumns.splice(colIdx, 1))
+                    const col = colById.get(id)
+                    if (col !== undefined) {
+                        orderedFlatColumns.push(col)
+                        seen.add(id)
+                    }
                 })
                 if (!hideUnspecifiedColumns) {
-                    // Push the remaining unspecified columns.
-                    orderedFlatColumns.push(..._flatColumns)
+                    $flatColumns.forEach((c) => {
+                        if (!seen.has(c.id)) orderedFlatColumns.push(c)
+                    })
                 }
                 return orderedFlatColumns
             })

--- a/src/lib/plugins/addColumnOrder.ts
+++ b/src/lib/plugins/addColumnOrder.ts
@@ -59,18 +59,18 @@ export const addColumnOrder =
             return derived([flatColumns, columnIdOrder], ([$flatColumns, $columnIdOrder]) => {
                 const colById = new Map($flatColumns.map((c) => [c.id, c]))
                 const orderedFlatColumns: typeof $flatColumns = []
-                const seen = new Set<string>()
                 $columnIdOrder.forEach((id) => {
                     const col = colById.get(id)
                     if (col !== undefined) {
                         orderedFlatColumns.push(col)
-                        seen.add(id)
+                        colById.delete(id)
                     }
                 })
                 if (!hideUnspecifiedColumns) {
-                    $flatColumns.forEach((c) => {
-                        if (!seen.has(c.id)) orderedFlatColumns.push(c)
-                    })
+                    // Remaining entries preserve original $flatColumns order.
+                    for (const col of colById.values()) {
+                        orderedFlatColumns.push(col)
+                    }
                 }
                 return orderedFlatColumns
             })

--- a/src/lib/plugins/addGroupBy.ts
+++ b/src/lib/plugins/addGroupBy.ts
@@ -160,8 +160,12 @@ export const getGroupedRows = <
                 `Missing \`getGroupOn\` column option to aggregate column "${groupById}" with object values`
             )
         }
-        const subRows = subRowsForGroupOnValue.get(groupOnValue) ?? []
-        subRowsForGroupOnValue.set(groupOnValue, [...subRows, row])
+        let subRows = subRowsForGroupOnValue.get(groupOnValue)
+        if (subRows === undefined) {
+            subRows = []
+            subRowsForGroupOnValue.set(groupOnValue, subRows)
+        }
+        subRows.push(row)
     }
 
     const groupedRows: Row[] = []


### PR DESCRIPTION
## Summary

Eliminates O(n²) and O(rows × cols²) hot-path bottlenecks in the table rendering pipeline. Every change targets loops that run on every reactive update (data change, sort, filter, paginate), replacing linear scans and array copies with Map/Set lookups and in-place mutations.

## Changes

⚡ **Performance**
- Replace `cells.find()` with Map lookup in `getColumnedBodyRows` — O(cols) per row instead of O(cols²)
- Replace `findIndex` + `splice` with Map + `delete` in `addColumnOrder` — O(c) instead of O(c²), also fixes non-existent column ID handling
- Replace `[...subRows, row]` spread-copy with `push()` in `addGroupBy` — O(n) instead of O(n²) for grouping
- Collapse two separate row iteration passes (state injection + hook application) into a single row-first pass in `createViewModel`
- Remove redundant `injectState` + `applyHook` pass in `injectedPageRows` — page rows are the same object references already processed by `injectedRows`

🔧 **Refactoring**
- Reuse `cellById` Map for `cellForId` population via `Object.fromEntries`
- Hoist hook functions into local variables to eliminate non-null assertions
- Replace `seen` Set with `colById.delete()` for cleaner unspecified-column handling

🧪 **Tests**
- Update `addColumnOrder` test expectation: non-existent column IDs are now skipped gracefully instead of causing splice side effects

## Commits

- [`c091597`](https://github.com/humanspeak/svelte-headless-table/commit/c091597aad354ae900edf87cf939e1fc35d573bd) perf(createViewModel): collapse state injection and hook application into row-first pass
- [`44a5444`](https://github.com/humanspeak/svelte-headless-table/commit/44a54448375940532258e4e643d0f82a8bc814c6) perf(addGroupBy): replace O(n²) spread-copy with O(n) push in grouping loop
- [`32d48bc`](https://github.com/humanspeak/svelte-headless-table/commit/32d48bc6f2992554fe6b19731fcb17c94c79bc63) perf(addColumnOrder): replace O(c²) findIndex+splice with O(c) Map lookup
- [`e0f948f`](https://github.com/humanspeak/svelte-headless-table/commit/e0f948f49f5d1a90a26f8d4af4339b2bc03630fe) perf(getColumnedBodyRows): replace O(c²) find with O(c) Map lookup
- [`b8a4289`](https://github.com/humanspeak/svelte-headless-table/commit/b8a4289be2f7140d7144518247e59d811663faa3) refactor: simplify post-review cleanup across perf changes
- [`7500eca`](https://github.com/humanspeak/svelte-headless-table/commit/7500eca1152c072be0aa6ff462115722e20ab126) perf(injectedPageRows): remove redundant inject+hook pass on page rows
