### PR TITLE
fix(seo): use page.data for unique SSR titles

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
         "test:unit": "vitest"
     },
     "dependencies": {
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.3.11",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.3.13",
         "@humanspeak/svelte-headless-table": "workspace:*",
         "@humanspeak/svelte-motion": "^0.1.31",
         "github-slugger": "^2.0.0"

--- a/docs/src/routes/+layout.svelte
+++ b/docs/src/routes/+layout.svelte
@@ -14,10 +14,7 @@
     const { children } = $props()
 
     // SEO state — owned here, passed to SeoContextProvider for child access
-    const seo = $state<SeoContext>({
-        title: `${docsConfig.name} - Headless Table Component for Svelte 5`,
-        description: docsConfig.description
-    })
+    const seo = $state<SeoContext>({})
 
     const npmUrl = `https://www.npmjs.com/package/${docsConfig.npmPackage}`
     const repoUrl = `https://github.com/${docsConfig.repo}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
   docs:
     dependencies:
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.3.11
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a2d49da2f4c021e2bd72c02b77ad2bba6d484289(@humanspeak/svelte-motion@0.1.31(svelte@5.53.7))(@internationalized/date@3.12.0)(@lucide/svelte@0.577.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)(zod@4.3.6)
+        specifier: github:humanspeak/docs-kit#2026.3.13
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/2014a516577b84e7a51fa200755651dceddfdb04(@humanspeak/svelte-motion@0.1.31(svelte@5.53.7))(@internationalized/date@3.12.0)(@lucide/svelte@0.577.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)(zod@4.3.6)
       '@humanspeak/svelte-headless-table':
         specifier: workspace:*
         version: link:..
@@ -795,8 +795,8 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a2d49da2f4c021e2bd72c02b77ad2bba6d484289':
-    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a2d49da2f4c021e2bd72c02b77ad2bba6d484289}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/2014a516577b84e7a51fa200755651dceddfdb04':
+    resolution: {tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/2014a516577b84e7a51fa200755651dceddfdb04}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-motion': '>=0.1.0'
@@ -4165,7 +4165,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a2d49da2f4c021e2bd72c02b77ad2bba6d484289(@humanspeak/svelte-motion@0.1.31(svelte@5.53.7))(@internationalized/date@3.12.0)(@lucide/svelte@0.577.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)(zod@4.3.6)':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/2014a516577b84e7a51fa200755651dceddfdb04(@humanspeak/svelte-motion@0.1.31(svelte@5.53.7))(@internationalized/date@3.12.0)(@lucide/svelte@0.577.0(svelte@5.53.7))(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))(mode-watcher@1.1.0(svelte@5.53.7))(svelte@5.53.7)(zod@4.3.6)':
     dependencies:
       '@humanspeak/svelte-motion': 0.1.31(svelte@5.53.7)
       '@humanspeak/svelte-satori-fix': 0.0.3(svelte@5.53.7)


### PR DESCRIPTION
## Summary
- Update docs-kit to 2026.3.13 which resolves duplicate title/description in SSR HTML
- Remove hardcoded default SEO values from root layout, letting page.data drive titles
- Fixes Ahrefs site audit warnings for duplicate metadata

## Test plan
- [ ] Build docs and inspect SSR HTML for unique titles per page
- [ ] Verify home page title includes project name
- [ ] Verify client-side navigation still updates document.title

🤖 Generated with [Claude Code](https://claude.com/claude-code)