### PR TITLE
ci: read pnpm release version from package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,6 +21,7 @@ on:
             - '!src/routes/**'
             - package.json
             - pnpm-lock.yaml
+            - pnpm-workspace.yaml
             - .github/workflows/npm-publish.yml
     workflow_dispatch:
         inputs:
@@ -473,9 +474,11 @@ jobs:
                       ;;
                   esac
 
-                  # Get the new version number
-                  NEW_VERSION=$(pnpm version "$BUMP_TYPE" --no-git-tag-version)
-                  echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+                  # Mutate package.json only — do NOT parse pnpm stdout (pnpm 11 prints multi-line text)
+                  pnpm version "$BUMP_TYPE" --no-git-tag-version
+                  PACKAGE_VERSION=$(node -p "require('./package.json').version")
+                  NEW_VERSION="v${PACKAGE_VERSION}"
+                  echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
                   # Escape special characters in PR title and URL
                   ESCAPED_TITLE=$(echo "$PR_TITLE" | sed 's/[`$"\]/\\&/g')


### PR DESCRIPTION
## Summary

This PR updates the npm publish workflow to derive release versions from the mutated `package.json` instead of parsing `pnpm version` stdout. PNPM 11 can print multi-line output, so reading the package version keeps the release output compatible with PNPM 10 and 11.

## Changes

- 🔄 CI/CD
  - Run `pnpm version` only to mutate `package.json`.
  - Read the resulting version with Node and emit a normalized `v${version}` value to `GITHUB_OUTPUT`.
  - Include `pnpm-workspace.yaml` in publish workflow trigger paths.

## Commits

- [`1d8c61a`](https://github.com/humanspeak/svelte-headless-table/commit/1d8c61a28eae4b562cd38e9ea50f573e62127c24) ci: read pnpm release version from package
