### PR TITLE
ci(npm-publish): refresh README ecosystem footer on release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -484,8 +484,23 @@ jobs:
                   ESCAPED_TITLE=$(echo "$PR_TITLE" | sed 's/[`$"\]/\\&/g')
                   ESCAPED_URL=$(echo "$PR_URL" | sed 's/[`$"\]/\\&/g')
 
-                  # Commit the version changes
-                  git add package.json
+                  # Refresh the managed README footer (the docs-kit ecosystem block +
+                  # standardized License/Credits). Runs AFTER `pnpm version` so the
+                  # working tree is clean when pnpm runs — pnpm version aborts on a
+                  # dirty tree. Fetched raw from the private docs-kit repo (no install,
+                  # no dependency here); reuses $GITHUB_TOKEN (ACTIONS_KEY) for auth.
+                  # Best-effort: a failed fetch or roster blip only warns.
+                  UPDATER="$RUNNER_TEMP/update-ecosystem-readme.mjs"
+                  if curl -fsSL -H "Authorization: token $GITHUB_TOKEN" \
+                      https://raw.githubusercontent.com/humanspeak/docs-kit/main/scripts/update-ecosystem-readme.mjs \
+                      -o "$UPDATER"; then
+                      node "$UPDATER" || echo "::warning::ecosystem updater errored; README left unchanged"
+                  else
+                      echo "::warning::could not fetch ecosystem updater; skipping README refresh"
+                  fi
+
+                  # Commit the version changes (and any refreshed README ecosystem block)
+                  git add package.json README.md
                   git commit -m "Bump version to ${NEW_VERSION} [skip ci]"
 
                   # Create an annotated tag with release notes


### PR DESCRIPTION
## What

Adds a best-effort step to the publish workflow that fetches docs-kit's standalone, dependency-free README updater from the private `humanspeak/docs-kit` repo and runs it during the version bump (after `pnpm version`, before the commit). It rewrites the managed README footer — the **Svelte 5 ecosystem** cross-link table plus standardized `## License` + `## Credits` — and folds `README.md` into the signed version-bump commit.

No new dependency here: the updater is `curl`ed raw and run with `node`. Best-effort — a failed fetch or roster blip only logs a `::warning::`, never fails the release.

Same pattern proven in `svelte-markdown` (published `@humanspeak/svelte-markdown@1.6.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)