### PR TITLE
build(docs): bump docs-kit to 2026.7.6

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.6.10",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.7.6",
         "@humanspeak/svelte-headless-table": "workspace:*",
         "@humanspeak/svelte-markdown": "^1.6.0",
         "@humanspeak/svelte-motion": "^0.6.6",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "peerDependencies": {
         "svelte": "^5.30.0"
     },
-    "packageManager": "pnpm@11.5.1",
+    "packageManager": "pnpm@11.9.0",
     "volta": {
         "node": "24.15.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.6.10
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5de65c4bb341e77aab593032d895ae2f1c7ad325(@humanspeak/svelte-markdown@1.6.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@humanspeak/svelte-motion@0.6.6(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.18.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@sveltejs/kit@2.65.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(shiki@4.2.0)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(zod@4.4.3)
+        specifier: github:humanspeak/docs-kit#2026.7.6
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc(@humanspeak/svelte-markdown@1.6.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@humanspeak/svelte-motion@0.6.6(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.18.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@sveltejs/kit@2.65.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(shiki@4.2.0)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(zod@4.4.3)
       '@humanspeak/svelte-headless-table':
         specifier: workspace:*
         version: link:..
@@ -823,8 +823,8 @@ packages:
     resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5de65c4bb341e77aab593032d895ae2f1c7ad325':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/5de65c4bb341e77aab593032d895ae2f1c7ad325}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4269,7 +4269,7 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/5de65c4bb341e77aab593032d895ae2f1c7ad325(@humanspeak/svelte-markdown@1.6.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@humanspeak/svelte-motion@0.6.6(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.18.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@sveltejs/kit@2.65.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(shiki@4.2.0)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(zod@4.4.3)':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc(@humanspeak/svelte-markdown@1.6.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@humanspeak/svelte-motion@0.6.6(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.18.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@sveltejs/kit@2.65.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(shiki@4.2.0)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(zod@4.4.3)':
     dependencies:
       '@humanspeak/svelte-motion': 0.6.6(svelte@5.56.3(@typescript-eslint/types@8.61.0))
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.3(@typescript-eslint/types@8.61.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
     - '@humanspeak/*'
 allowBuilds:
+    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc': true
     '@humanspeak/docs-kit': true
     esbuild: true
     sharp: true


### PR DESCRIPTION
Bumps `@humanspeak/docs-kit` to `2026.7.6`, adds the `allowBuilds` resolved-commit key in `pnpm-workspace.yaml`, and bumps `packageManager` to `pnpm@11.9.0` (the resolved-URL key format requires it — pnpm 11.9 matches git-hosted deps by `name@resolved-url`). Lockfile re-resolved.

Mirrors the setup already on `svelte-motion`. Supersedes the stale `codex/docs-kit-upgrade` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)