### PR TITLE
fix(docs): drop HTML tags from social-card feature labels

### DIFF
--- a/docs/src/routes/docs/api/render/+page.svx
+++ b/docs/src/routes/docs/api/render/+page.svx
@@ -14,7 +14,7 @@ sidebar_title: Render
       seo.description = 'Use the Render component to display Svelte components configured as render configs within your table cells, headers, and other customizable table elements'
       seo.ogTitle = 'Render Component'
       seo.ogTagline = 'Display Svelte components configured as render configs.'
-      seo.ogFeatures = ['<Render />', 'createRender', 'Custom Cells', 'Headers']
+      seo.ogFeatures = ['Render', 'createRender', 'Custom Cells', 'Headers']
       seo.ogSlug = 'api-render'
   }
 </script>

--- a/docs/src/routes/docs/api/subscribe/+page.svx
+++ b/docs/src/routes/docs/api/subscribe/+page.svx
@@ -17,7 +17,7 @@ sidebar_title: Subscribe
       seo.description = 'Subscribe to non top-level Svelte stores within your template using the Subscribe component for reactive access to nested store values and plugin state'
       seo.ogTitle = 'Subscribe Component'
       seo.ogTagline = 'Subscribe to nested stores within your template.'
-      seo.ogFeatures = ['<Subscribe />', 'Nested Stores', 'Reactive', 'Plugin State']
+      seo.ogFeatures = ['Subscribe', 'Nested Stores', 'Reactive', 'Plugin State']
       seo.ogSlug = 'api-subscribe'
   }
 </script>


### PR DESCRIPTION
The docs Cloudflare deploy has been failing since the docs-kit 2026.7.6 bump (#251) with:

> `[plugin docs-kit:social-cards]` Error: Expected `<div>` to have explicit "display: flex", "display: contents", or "display: none" if it has more than one child node.

**Root cause:** the social-cards plugin interpolates `seo.ogFeatures` raw into its satori HTML template. The API pages for `Render` and `Subscribe` used literal `'<Render />'` / `'<Subscribe />'` labels, which `satori-html` parses as child *elements* — tripping satori's explicit-display rule inside the feature cell. (Entity-escaping doesn't work either: `satori-html` doesn't decode entities, so `&lt;Render /&gt;` would render literally.)

**Fix:** plain-text labels (`Render`, `Subscribe`). Verified locally: full `pnpm build` in `docs/` passes and the generated `og-api-render.png` / `og-api-subscribe.png` cards render correctly.

Follow-up worth considering in docs-kit itself: HTML-escape interpolated strings in the social-card template so consumer data can't break the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)