### PR TITLE
ci: update all GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -29,14 +29,14 @@ jobs:
         name: Deploy
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
 
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
                   cache: pnpm
@@ -79,7 +79,7 @@ jobs:
 
             - name: Upload Wrangler logs
               if: always()
-              uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+              uses: actions/upload-artifact@v7 # zizmor: ignore[unpinned-uses]
               with:
                   name: wrangler-logs
                   path: ~/.config/.wrangler/logs/*.log

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,15 +20,15 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name != github.repository
 
         steps:
-            - uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+            - uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 0
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v3 # zizmor: ignore[unpinned-uses]
+              uses: github/codeql-action/init@v4 # zizmor: ignore[unpinned-uses]
               with:
                   languages: javascript
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v3 # zizmor: ignore[unpinned-uses]
+              uses: github/codeql-action/analyze@v4 # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -19,7 +19,7 @@ jobs:
                 node-version: [22, 24]
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
@@ -27,7 +27,7 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: ${{ matrix.node-version }}
 
@@ -46,7 +46,7 @@ jobs:
               if: matrix.node-version == '22'
 
             - name: Cache dependencies
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -68,7 +68,7 @@ jobs:
         environment: ci
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
@@ -158,7 +158,7 @@ jobs:
 
             - name: Upload Results
               if: failure() && github.event_name == 'pull_request'
-              uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              uses: actions/github-script@v9 # zizmor: ignore[unpinned-uses]
               with:
                   github-token: ${{ secrets.ACTIONS_KEY }}
                   script: |
@@ -213,7 +213,7 @@ jobs:
             packages: write
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
@@ -221,7 +221,7 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: ${{ matrix.node-version }}
 
@@ -260,14 +260,14 @@ jobs:
         runs-on: blacksmith-4vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         environment: ci
         steps:
-            - uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+            - uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.ACTIONS_KEY }}
 
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
-            - uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+            - uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
 
@@ -288,7 +288,7 @@ jobs:
                   org-slug: ${{ secrets.TRUNK_ORG_SLUG }}
                   token: ${{ secrets.TRUNK_TOKEN }}
 
-            - uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+            - uses: actions/upload-artifact@v7 # zizmor: ignore[unpinned-uses]
               if: always()
               with:
                   name: playwright-results
@@ -332,7 +332,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   token: ${{ secrets.GITHUB_TOKEN }}
@@ -341,7 +341,7 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses,cache-poisoning]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses,cache-poisoning]
               with:
                   node-version: 24
 
@@ -382,7 +382,7 @@ jobs:
 
             - name: Create Comment on Skip
               if: github.event_name == 'pull_request' && steps.publish-check.outputs.should_publish == 'false'
-              uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              uses: actions/github-script@v9 # zizmor: ignore[unpinned-uses]
               with:
                   github-token: ${{ secrets.ACTIONS_KEY }}
                   script: |
@@ -396,7 +396,7 @@ jobs:
             - name: Import GPG key
               if: steps.publish-check.outputs.should_publish == 'true'
               id: import_gpg
-              uses: crazy-max/ghaction-import-gpg@v6 # zizmor: ignore[unpinned-uses]
+              uses: crazy-max/ghaction-import-gpg@v7 # zizmor: ignore[unpinned-uses]
               with:
                   gpg_private_key: ${{ secrets.ACTIONS_GPG_PRIVATE_KEY }}
                   passphrase: ${{ secrets.ACTIONS_GPG_PASSPHRASE }}
@@ -567,7 +567,7 @@ jobs:
 
             - name: Notify on failure
               if: failure()
-              uses: actions/github-script@v7 # zizmor: ignore[unpinned-uses]
+              uses: actions/github-script@v9 # zizmor: ignore[unpinned-uses]
               with:
                   github-token: ${{ secrets.ACTIONS_KEY }}
                   script: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 1
@@ -39,12 +39,12 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
 
             - name: Cache build artifacts
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: |
                       .svelte-kit
@@ -54,7 +54,7 @@ jobs:
                       ${{ runner.os }}-build-
 
             - name: Cache vitest artifacts
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: |
                       node_modules/.vitest
@@ -73,7 +73,7 @@ jobs:
 
             - name: Upload unit test results
               if: always()
-              uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+              uses: actions/upload-artifact@v7 # zizmor: ignore[unpinned-uses]
               with:
                   name: unit-test-results
                   path: |
@@ -96,7 +96,7 @@ jobs:
                       shard_name: 2-2
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 1
@@ -104,7 +104,7 @@ jobs:
             - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
             - name: Use Node.js - 24
-              uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
 
@@ -112,7 +112,7 @@ jobs:
               run: pnpm install --filter . --frozen-lockfile --config.engine-strict=false
 
             - name: Cache Playwright browsers
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: ~/.cache/ms-playwright
                   key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -132,7 +132,7 @@ jobs:
 
             - name: Upload Playwright artifacts
               if: always()
-              uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+              uses: actions/upload-artifact@v7 # zizmor: ignore[unpinned-uses]
               with:
                   name: playwright-artifacts-${{ matrix.shard_name }}
                   path: |

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
 
         steps:
-            - uses: actions/stale@v10 # zizmor: ignore[unpinned-uses]
+            - uses: actions/stale@v11 # zizmor: ignore[unpinned-uses]
               with:
                   # PR specific settings
                   stale-pr-message: This PR is being marked as stale due to 30 days of inactivity. It will be closed in 5 days if no further activity occurs.

--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -16,7 +16,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
 

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -15,13 +15,13 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         steps:
             - name: Checkout
-              uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/checkout@v7 # zizmor: ignore[unpinned-uses]
               with:
                   persist-credentials: false
                   fetch-depth: 0 # Fetch full history for git comparisons
 
             - name: Set up Python
-              uses: actions/setup-python@v6 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-python@v7 # zizmor: ignore[unpinned-uses]
               with:
                   python-version: '3.12'
 
@@ -40,7 +40,7 @@ jobs:
                   fi
 
             - name: Cache uv installation
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: ~/.local/bin/uv
                   key: ${{ runner.os }}-uv-${{ steps.uv-version.outputs.version }}
@@ -64,7 +64,7 @@ jobs:
                   # echo "version=test-version-$(date +%s)" >> $GITHUB_OUTPUT
 
             - name: Cache zizmor tool
-              uses: actions/cache@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/cache@v6 # zizmor: ignore[unpinned-uses]
               with:
                   path: |
                       ~/.local/bin/zizmor

--- a/.trunk/setup-ci/action.yaml
+++ b/.trunk/setup-ci/action.yaml
@@ -7,7 +7,7 @@ runs:
         - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
 
         - name: Setup Node.js
-          uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
+          uses: actions/setup-node@v7 # zizmor: ignore[unpinned-uses]
           with:
               node-version: 24
 


### PR DESCRIPTION
## Summary

Bumps every GitHub Action across the workflows (and the `.trunk/setup-ci` composite action) to its latest major version. CI-only change — no runtime or package code is touched, so publishing is skipped.

## Changes

- 🔄 `actions/checkout` v6 → v7
- 🔄 `actions/setup-node` v6 → v7 (workflows + `.trunk/setup-ci/action.yaml`)
- 🔄 `actions/setup-python` v6 → v7
- 🔄 `actions/cache` v5 → v6
- 🔄 `actions/upload-artifact` v4 → v7
- 🔄 `actions/stale` v10 → v11
- 🔄 `actions/github-script` v7 → v9
- 🔄 `github/codeql-action` (init/analyze) v3 → v4
- 🔄 `crazy-max/ghaction-import-gpg` v6 → v7

Already on the latest major (unchanged): `pnpm/action-setup@v6`, `coverallsapp/github-action@v2`, `trunk-io/trunk-action@v1`; `trunk-io/analytics-uploader` intentionally tracks `main`.

## Commits

- [`1b25481`](https://github.com/humanspeak/svelte-headless-table/commit/1b25481e7f592adaa0159caa68207992d8b366ac) ci: update all GitHub Actions to latest major versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
